### PR TITLE
Update SN to 23xxxxxxxx for i2c address change

### DIFF
--- a/example-i2c-address-change/README.md
+++ b/example-i2c-address-change/README.md
@@ -87,7 +87,7 @@ sudo make install
 
 ## Limitations
 
-- The feature is only supported by SLF3x sensors with a serial number above 22xxxxxxxx.
+- The feature is only supported by SLF3x sensors with a serial number above 23xxxxxxxx.
 - After a soft reset (specific I2C command) or hard reset (power cycle) the I²C address is set back to the default address 0x08.
 
 ## Further readings

--- a/example-i2c-address-change/slf3x_example_i2c_address_change.c
+++ b/example-i2c-address-change/slf3x_example_i2c_address_change.c
@@ -74,7 +74,7 @@ void i2c_soft_reset() {
  *   after the reset)
  * * IRQn Pin (Pin 1) of the sensor for which you want to change the address
  *   must be connected to a GPIO pin
- * * Note that only sensors with a serial number above 22xxxxxxxx have the IRQn
+ * * Note that only sensors with a serial number above 23xxxxxxxx have the IRQn
  *   pin
  *
  * @note The I2C address is not configured permanently, you need to run the


### PR DESCRIPTION
Only sensors with serial number starting with 23xxx or newer are guaranteed to support the i2c address change. Not all sensors with serial number 22xxx support the feature.